### PR TITLE
fix invalid escapes of variables

### DIFF
--- a/web-build/pre.Dockerfile.proxy-support
+++ b/web-build/pre.Dockerfile.proxy-support
@@ -14,9 +14,9 @@ ENV NO_PROXY=${NO_PROXY:-127.0.0.1}
 ENV http_proxy=${http_proxy:-${HTTP_PROXY}}
 
 RUN if [ ! -z "${HTTP_PROXY:-}" ] || [ ! -z "${HTTPS_PROXY:-}" ]; then \
-    printf "Acquire {\nHTTP::proxy \"${HTTP_PROXY:-}\";\nHTTPS::proxy \"${HTTPS_PROXY:-}\";\n}\n"  > /etc/apt/apt.conf.d/proxy.conf ; \
+    printf "Acquire {\nHTTP::proxy \"%s\";\nHTTPS::proxy \"%s\";\n}\n" "${HTTP_PROXY:-}" "${HTTPS_PROXY:-}" > /etc/apt/apt.conf.d/proxy.conf ; \
 fi
 
 # Debugging statements
-RUN echo "Using HTTP_PROXY='${HTTP_PROXY:-}' HTTPS_PROXY='${HTTPS_PROXY:-}' NO_PROXY='${NO_PROXY:-}'"
+RUN printf "Using HTTP_PROXY='%s' HTTPS_PROXY='%s' NO_PROXY='%s'" "${HTTP_PROXY:-}" "${HTTPS_PROXY:-}" "${NO_PROXY:-}"
 RUN if [ -f /etc/apt/apt.conf.d/proxy.conf ]; then cat /etc/apt/apt.conf.d/proxy.conf ; fi


### PR DESCRIPTION
currently the printf statement doesn't format the string, which causes the build of the container to fail on f.e. quoted @ characters of users like with the following setup:
`HTTPS_PROXY='https://test%40test.com:%23test%23@test.de:89'`

resulting in an invalid directive error:
```#12 [drud/ddev-webserver:v1.21.3-playground-11-built  3/10] RUN if [ ! -z "" ] || [ ! -z "https://test%40test.com:%23test%23@test.de:89" ]; then     printf "Acquire {\nHTTP::proxy "";\nHTTPS::proxy "https://test%40test.com:%23test%23@test.de:89";\n}\n"  > /etc/apt/apt.conf.d/proxy.conf ; fi
#12 0.399 /bin/sh: 1: printf: %40t: invalid directive
#12 ERROR: executor failed running [/bin/sh -c if [ ! -z "${HTTP_PROXY:-}" ] || [ ! -z "${HTTPS_PROXY:-}" ]; then     printf "Acquire {\nHTTP::proxy \"${HTTP_PROXY:-}\";\nHTTPS::proxy \"${HTTPS_PROXY:-}\";\n}\n"  > /etc/apt/apt.conf.d/proxy.conf ; fi]: exit code: 2```