### PR TITLE
`drud` → `ddev`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  NIGHTLY_DDEV_PR_URL: "https://nightly.link/drud/ddev/actions/runs/2682419555/ddev-linux-amd64.zip"
+  NIGHTLY_DDEV_PR_URL: "https://nightly.link/ddev/ddev/actions/runs/2682419555/ddev-linux-amd64.zip"
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Allow `--HEAD` flag when running tests against HEAD
@@ -53,15 +53,15 @@ jobs:
 
     - name: Use ddev stable
       if: matrix.ddev_version == 'stable'
-      run: brew install drud/ddev/ddev
+      run: brew install ddev/ddev/ddev
 
     - name: Use ddev edge
       if: matrix.ddev_version == 'edge'
-      run: brew install drud/ddev-edge/ddev
+      run: brew install ddev/ddev-edge/ddev
 
     - name: Use ddev HEAD
       if: matrix.ddev_version == 'HEAD'
-      run: brew install --HEAD drud/ddev/ddev
+      run: brew install --HEAD ddev/ddev/ddev
 
     - name: Use ddev PR
       if: matrix.ddev_version == 'PR'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![tests](https://github.com/drud/ddev-proxy-support/actions/workflows/tests.yml/badge.svg)](https://github.com/drud/ddev-proxy-support/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2023.svg)
+[![tests](https://github.com/ddev/ddev-proxy-support/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-proxy-support/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2023.svg)
 
 # DDEV Proxy support
 
-Install this with `ddev get drud/ddev-proxy-support`
+Install this with `ddev get ddev/ddev-proxy-support`
 
 It installs a docker-compose.proxy.yaml and pre.Dockerfile.proxy-support which add proxy capabilities to DDEV v1.19.5+
 
@@ -14,6 +14,6 @@ Details about how to lab-test this are in [Lab-testing a proxied environment](la
 
 You can also find public proxies of varying reliability at [spys](https://spys.one/free-proxy-list/US/) and other places, and of course you would never trust them with any traffic, but they're useful for testing.
 
-**Contributed and maintained by [@rfay](https://github.com/rfay) based on the original [ddev-contrib recipe](https://github.com/drud/ddev-contrib/tree/master/recipes/proxy).**
+**Contributed and maintained by [@rfay](https://github.com/rfay) based on the original [ddev-contrib recipe](https://github.com/ddev/ddev-contrib/tree/master/recipes/proxy).**
 
 

--- a/lab-testing.md
+++ b/lab-testing.md
@@ -35,4 +35,4 @@ I used Parallels on macOS for the test lab.
 * Verified that curl against internet https locations now worked on the "workstation".
 * Configured the docker server as in [docker server instructions](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy), and verified that `docker pull ubuntu` now worked on "workstation" using the proxy.
 * Configured the docker client as in [docker client instructions](https://docs.docker.com/network/proxy/#configure-the-docker-client) and verified that proxy setup was now right in the container by `ddev start`, `ddev ssh`, and using curl inside the container against an HTTPS website.
-* `ddev get drud/ddev-proxy-support` installs the [pre.Dockerfile.proxy-support](web-build/pre.Dockerfile.proxy-support) which enables apt support of the proxy.
+* `ddev get ddev/ddev-proxy-support` installs the [pre.Dockerfile.proxy-support](web-build/pre.Dockerfile.proxy-support) which enables apt support of the proxy.

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -48,8 +48,8 @@ teardown() {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   ddev stop
-  echo "# ddev get drud/ddev-proxy-support with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get drud/ddev-proxy-support
+  echo "# ddev get ddev/ddev-proxy-support with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev get ddev/ddev-proxy-support
   ddev debug refresh
   ddev start
   export HTTP_PROXY=${TEST_PROXY_URL}


### PR DESCRIPTION
Turns a bunch of `drud`s into `ddev`s, with caution to the wind for the GitHub workflow and tests.

If nothing’s wrecked, please pull whenever you’d like!